### PR TITLE
Fixes for finding /usr/bin/env and FORMAT value preparation with BIAS

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 use warnings;
 use Getopt::Std;
@@ -165,8 +165,8 @@ foreach my $chr (@chrs) {
 	my $filter = @filters > 0 ? join(";", @filters) : "PASS";
 	my $gt = (1-$af1 < $GTFreq) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $Freq ? "0/1" : "0/0"));
 	my $gtm = (1-$af2 < $GTFreq) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $Freq ? "0/1" : "0/0"));
-	$bias1 =~ s/;/:/;
-	$bias2 =~ s/;/:/;
+	$bias1 =~ s/;/,/;
+	$bias2 =~ s/;/,/;
 	my $qual = $vd1 > $vd2 ? int(log($vd1)/log(2) * $qual1) : int(log($vd2)/log(2) * $qual2);
 	if ( $pfilter eq "PASS" && $pinfo2 =~ /Somatic/ && $pinfo2 =~ /TYPE=SNV/ && $filter eq "PASS" && $status =~ /Somatic/ && $type eq "SNV" && $start - $pvs < $opt_c ) {
 	    $pfilter = "Cluster${opt_c}bp";

--- a/var2vcf_somatic.pl
+++ b/var2vcf_somatic.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 
 use warnings;
 use Getopt::Std;
@@ -165,8 +165,8 @@ foreach my $chr (@chrs) {
 	my $filter = @filters > 0 ? join(";", @filters) : "PASS";
 	my $gt = (1-$af1 < $GTFreq) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $Freq ? "0/1" : "0/0"));
 	my $gtm = (1-$af2 < $GTFreq) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $Freq ? "0/1" : "0/0"));
-	$bias1 =~ s/;/:/;
-	$bias2 =~ s/;/:/;
+	$bias1 =~ s/;/,/;
+	$bias2 =~ s/;/,/;
 	my $qual = $vd1 > $vd2 ? int(log($vd1)/log(2) * $qual1) : int(log($vd2)/log(2) * $qual2);
 	if ( $pfilter eq "PASS" && $pinfo2 =~ /Somatic/ && $pinfo2 =~ /TYPE=SNV/ && $filter eq "PASS" && $status =~ /Somatic/ && $type eq "SNV" && $start - $pvs < $opt_c ) {
 	    $pfilter = "Cluster${opt_c}bp";

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/env perl
 use warnings;
 use Getopt::Std;
 use strict;


### PR DESCRIPTION
The recent changes to VarDict swapping `/usr/bin/env` to `/bin/env`
break execution on Ubuntu systems where `env` in only in `/usr/bin`. One
CentOS it is in both places, so `/usr/bin` seems like the more widely
supported path.

The recent bias change also causes issues by creating too many values.
GATK complains with:

```
The provided VCF file is malformed at approximately line number 52:
There are too many keys for the sample c-tumor, keys = GT:DP:VD:AD:RD:AF:BIAS:PMEAN:PSTD:QUAL:QSTD:SBF:ODDRATIO:MQ:SN:HIAF:ADJAF:NM1/1:64:64:35,29:0,0:1:0:2:20.4:1:31.1:1:1:0:60:15:1:0:1.201/1:37:37:20,17:0,0:1:0:2:25.6:1:32.5:1:1:0:60:36:1:0:1.1,
```

Since swapping in colon separation creates 19 values and only 18 keys.
This swaps it back to using comma separation instead.
