### PR TITLE
Cleaner way of handling empty stdin (no variants) for R post-processing

### DIFF
--- a/testsomatic.R
+++ b/testsomatic.R
@@ -2,14 +2,9 @@
 
 #args <- commandArgs(trailingOnly = TRUE)
 
-d <- tryCatch( {
-    d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, "character", NA, "character",  NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, "character", "character", "character", "character"))
-}, error = function(e) {
-    return(NULL)
-} )
+d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, "character", NA, "character",  NA, NA, NA, NA, NA, NA, NA, NA, NA, NA, "character", "character", "character", "character"), col.names=c(1:51) )
 
-
-if (!is.null(d)){
+if (nrow(d) > 0){
     pvalues1 <- vector(mode="double", length=dim(d)[1])
     oddratio1 <- vector(mode="double", length=dim(d)[1])
     pvalues2 <- vector(mode="double", length=dim(d)[1])

--- a/teststrandbias.R
+++ b/teststrandbias.R
@@ -2,14 +2,9 @@
 
 #args <- commandArgs(trailingOnly = TRUE)
 
-#d <- read.table( args[1], sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA))
-d <- tryCatch( {
-    read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA))
-}, error = function(e) {
-    return(NULL)
-} )
+d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:22))
 
-if (!is.null(d)){
+if (nrow(d) > 0){
     pvalues <- vector(mode="double", length=dim(d)[1])
     oddratio <- vector(mode="double", length=dim(d)[1])
     


### PR DESCRIPTION
Miika;
This avoids a general tryCatch, which can mask errors in the underlying output (AstraZeneca-NGS/VarDictJava#3). The fix adds column names (as numbers) so the data.frame is always created but has no rows with empty stdin. Thanks much.