### PR TITLE
Fix for 'wrong number of columns' error on single sample calling

### DIFF
--- a/teststrandbias.R
+++ b/teststrandbias.R
@@ -2,7 +2,7 @@
 
 #args <- commandArgs(trailingOnly = TRUE)
 
-d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:22))
+d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:34))
 
 if (nrow(d) > 0){
     pvalues <- vector(mode="double", length=dim(d)[1])


### PR DESCRIPTION
This updates the columns in teststrandbias.R to match the output of VarDict
single sample calling. colClasses under-represents the total columns
handled but that doesn't cause issues unless we need to specifically
specify a later colClass.