### PR TITLE
Create teststrandbias_amplicon.R

### DIFF
--- a/teststrandbias_amplicon.R
+++ b/teststrandbias_amplicon.R
@@ -1,0 +1,22 @@
+#!/usr/bin/env Rscript
+
+#args <- commandArgs(trailingOnly = TRUE)
+
+#breaks amplicon calling
+#d <- read.table( file('stdin'), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:34))
+
+colClasses=c("character","character",NA,NA,NA,"character","character",NA,NA,NA,NA,NA,NA,"character",NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,"character","character","character","character",NA,NA,NA,NA)
+d <- read.table( "vardict.test.out",sep = "\t", header = F,colClasses=colClasses,col.names=c(1:38))
+
+if (nrow(d) > 0){
+    pvalues <- vector(mode="double", length=dim(d)[1])
+    oddratio <- vector(mode="double", length=dim(d)[1])
+
+    for( i in 1:dim(d)[1] ) {
+        h <- fisher.test(matrix(c(d[i,10], d[i,11], d[i,12], d[i,13]), nrow=2))
+        pvalues[i] <- round(h$p.value, 5)
+        oddratio[i] <- round(h$estimate, 5)
+    }
+    write.table(data.frame(d[,1:20], pvalues, oddratio, d[,21:dim(d)[2]]), file = "", quote = F, sep = "\t", eol = "\n", row.names=F, col.names=F)
+}
+


### PR DESCRIPTION
I noted that recent changes to read.table in teststrandbias.R (where a col.names argument is added) breaks the ability to operate on the output of amplicon mode.  The new R script fixes that by expecting col.names=c(1:38) rather than c(1:34). 