### PR TITLE
Correct LSEQ/RSEQ INFO specification

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -51,8 +51,8 @@ print <<VCFHEADER;
 ##INFO=<ID=MSILEN,Number=1,Type=Float,Description="MSI unit repeat length in bp">
 ##INFO=<ID=SSF,Number=1,Type=Float,Description="P-value">
 ##INFO=<ID=SOR,Number=1,Type=Float,Description="Odds ratio">
-##INFO=<ID=LSEQ,Number=G,Type=String,Description="5' flanking seq">
-##INFO=<ID=RSEQ,Number=G,Type=String,Description="3' flanking seq">
+##INFO=<ID=LSEQ,Number=1,Type=String,Description="5' flanking seq">
+##INFO=<ID=RSEQ,Number=1,Type=String,Description="3' flanking seq">
 ##INFO=<ID=STATUS,Number=1,Type=String,Description="Somatic or germline status">
 ##FILTER=<ID=q$qmean,Description="Mean Base Quality Below $qmean">
 ##FILTER=<ID=Q$Qmean,Description="Mean Mapping Quality Below $Qmean">

--- a/var2vcf_somatic.pl
+++ b/var2vcf_somatic.pl
@@ -51,8 +51,8 @@ print <<VCFHEADER;
 ##INFO=<ID=MSILEN,Number=1,Type=Float,Description="MSI unit repeat length in bp">
 ##INFO=<ID=SSF,Number=1,Type=Float,Description="P-value">
 ##INFO=<ID=SOR,Number=1,Type=Float,Description="Odds ratio">
-##INFO=<ID=LSEQ,Number=G,Type=String,Description="5' flanking seq">
-##INFO=<ID=RSEQ,Number=G,Type=String,Description="3' flanking seq">
+##INFO=<ID=LSEQ,Number=1,Type=String,Description="5' flanking seq">
+##INFO=<ID=RSEQ,Number=1,Type=String,Description="3' flanking seq">
 ##INFO=<ID=STATUS,Number=1,Type=String,Description="Somatic or germline status">
 ##FILTER=<ID=q$qmean,Description="Mean Base Quality Below $qmean">
 ##FILTER=<ID=Q$Qmean,Description="Mean Mapping Quality Below $Qmean">

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -57,8 +57,8 @@ print <<VCFHEADER;
 ##INFO=<ID=MSI,Number=1,Type=Float,Description="MicroSattelite. > 1 indicates MSI">
 ##INFO=<ID=MSILEN,Number=1,Type=Float,Description="MicroSattelite unit length in bp">
 ##INFO=<ID=NM,Number=1,Type=Float,Description="Mean mismatches in reads">
-##INFO=<ID=LSEQ,Number=G,Type=String,Description="5' flanking seq">
-##INFO=<ID=RSEQ,Number=G,Type=String,Description="3' flanking seq">
+##INFO=<ID=LSEQ,Number=1,Type=String,Description="5' flanking seq">
+##INFO=<ID=RSEQ,Number=1,Type=String,Description="3' flanking seq">
 ##INFO=<ID=GDAMP,Number=1,Type=Integer,Description="No. of amplicons supporting variant">
 ##INFO=<ID=TLAMP,Number=1,Type=Integer,Description="Total of amplicons covering variant">
 ##INFO=<ID=NCAMP,Number=1,Type=Integer,Description="No. of amplicons don't work">


### PR DESCRIPTION
Zhongwu
LSEQ and RSEQ had an INFO specification of Number=G, which is one value
per possible genotype. This is not correct with the usage, which I
believe is 1 flanking sequence per variant (Number=1). The incorrect
specification causes errors with downstream tools, like bcftools, that
check this:
```
Error at 1:10469: wrong number of fields in LSEQ?
```
Here is a small test case:

https://s3.amazonaws.com/chapmanb/az/bcftools_merge_lseq.tar.gz

Thanks much.