### PR TITLE
Fix nm check

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -27,7 +27,7 @@ my $E_col = $opt_E ? $opt_E - 1 : 7;
 my $s_col = $opt_s ? $opt_s - 1 : 9;
 my $e_col = $opt_e ? $opt_e - 1 : 10;
 my $g_col = $opt_g ? $opt_g - 1 : 12;
-$opt_m = $opt_m ? $opt_m : 8;
+$opt_m = $opt_m ne '' ? $opt_m : 8;
 
 $s_col = $S_col if ( $opt_S && (!$opt_s) );
 $e_col = $E_col if ( $opt_E && (!$opt_e) );

--- a/vardict.pl
+++ b/vardict.pl
@@ -634,13 +634,15 @@ sub parseSAM {
 	    my $nm = 0;
 	    my @segid = $a[5] =~ /(\d+)[ID]/g; # For total indels
 	    my $idlen = 0; $idlen += $_ foreach(@segid);
-	    if ( /NM:i:(\d+)/i ) {  # number of mismatches.  Don't use NM since it includes gaps, which can be from indels
-		$nm = $1 - $idlen;
-		next if ( $opt_m && $nm > $opt_m ); # edit distance - indels is the # of mismatches
-	    } else {
-		print STDERR "No XM tag for mismatches. $_\n" if ( $opt_y && $a[5] ne "*" );
-		next;
-	    }
+        if ( $opt_m ) {
+	        if ( /NM:i:(\d+)/i ) {  # number of mismatches.  Don't use NM since it includes gaps, which can be from indels
+	            $nm = $1 - $idlen;
+	            next if ( $nm > $opt_m ); # edit distance - indels is the # of mismatches
+	        } else {
+	            print STDERR "No XM tag for mismatches. $_\n" if ( $opt_y && $a[5] ne "*" );
+	            next;
+	        }
+        }
 	    my $n = 0; # keep track the read position, including softclipped
 	    my $p = 0; # keep track the position in the alignment, excluding softclipped
 	    my $dir = $a[1] & 0x10 ? "-" : "+";


### PR DESCRIPTION
Fixed: Unable to rest opt_m (set to 8 by default).
Fixed: Only check presence of NM tag in SAM files if opt_m is set.
