### PR TITLE
VCF: provide consistent output with empty inputs

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -96,6 +96,10 @@ print <<VCFHEADER;
 VCFHEADER
 
 print join("\t", "#CHROM", qw(POS ID REF ALT QUAL FILTER INFO FORMAT), $sample, $samplem), "\n";
+
+# Exit if we don't have any variants to write
+exit(0) unless( %hash );
+
 my @chrs = sort (keys %hash);
 foreach my $chr (@chrs) {
     my @pos = sort { $a <=> $b } (keys %{ $hash{ $chr } });

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -32,7 +32,6 @@ while(<>) {
     push( @{ $hash{ $chr }->{ $a[3] } }, \@a );
 }
 $sample = $opt_N if ( $opt_N );
-exit(0) unless( %hash );
 
 print <<VCFHEADER;
 ##fileformat=VCFv4.1
@@ -96,6 +95,10 @@ print <<VCFHEADER;
 VCFHEADER
 
 print join("\t", "#CHROM", qw(POS ID REF ALT QUAL FILTER INFO FORMAT), $sample), "\n";
+
+# Exit if we don't have any variants to write
+exit(0) unless( %hash );
+
 #my @chrs = map { "chr$_"; } (1..22);
 #push(@chrs, "chrX", "chrY", "chrM");
 #if ( $opt_C ) {


### PR DESCRIPTION
Previously when an input was empty var2vcf_valid.pl would output an
empty file while var2vcf_paired.pl would output a VCF header and spit
out a perl error message.

This update makes them both produce the VCF header without any variants,
avoiding the error message.

Provides a fix for chapmanb/bcbio-nextgen#1788