### PR TITLE
Sample error for empty inputs to var2vcf_paired

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -23,7 +23,7 @@ $opt_m = $opt_m ? $opt_m : 5.25;
 $opt_c = $opt_c ? $opt_c : 0;
 
 my %hash;
-my $sample;
+my $sample="tumor";
 while(<>) {
     chomp;
     next if (/R_HOME/);


### PR DESCRIPTION
Empty inputs from vardict-java trigger a perl string error when trying
to concatenate an unitialized $sample to create $samplem default naming.
If you use the `-N` flag the default naming is non-critical and
var2vcf_paired will make a correct empty VCF. This defaults to a string
based name instead of null, avoiding the error.