### PR TITLE
No comment character checking in teststrandbias.R

### DIFF
--- a/teststrandbias.R
+++ b/teststrandbias.R
@@ -11,7 +11,7 @@ if (length(myinput) > 0 ){
     d = matrix(0,0,0)
 }
 if (mynumcols == 34 || mynumcols == 38){ # 34 columns for standard bed files, 38 for amplicon mode
-    d <- read.table( textConnection(myinput), sep = "\t", header = F, colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:mynumcols))
+    d <- read.table( textConnection(myinput), sep = "\t", header = F, comment.char = "", colClasses=c("character", NA, NA, NA, NA, "character", "character", NA, NA, NA, NA, NA, NA, "character", NA, NA, NA, NA, NA, NA, NA, NA), col.names=c(1:mynumcols))
 } else if (mynumcols > 0){
     stop("Incorrect input detected in teststrandbias.R")
 }


### PR DESCRIPTION
We use the `#` character in interval names to signify order of intervals in BED files for both upstream and downstream analysis.

`teststrandbias.R` chokes on these interval names because `R`'s `read.table()` function has a default which interprets `#` symbols as the beginning of a comment.

This PR fixes that behaviour by turning off the interpretation of comments in VarDict output.

This is a safe patch because the interval name field (`$gene`) is **not** used in the creation of a VCF file and  `#` symbols are actually used to indicate commented lines in valid VCF files.