### PR TITLE
Fixes in roundings, script var2vcf_valid.pl, negative NM value and output for StrongLOH variants

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -115,7 +115,7 @@ foreach my $chr (@chrs) {
 	my %seen = ();
 	for(my $i = 0; $i < $ALL; $i++) {
 	    my $d = $tmp[$i]; # Only the highest AF get represented
-	    my ($sample, $gene, $chrt, $start, $end, $ref, $alt, $dp1, $vd1, $rfwd1, $rrev1, $vfwd1, $vrev1, $gt1, $af1, $bias1, $pmean1, $pstd1, $qual1, $qstd1, $mapq1, $sn1, $hiaf1, $adjaf1, $nm1, $sbf1, $oddratio1, $dp2, $vd2, $rfwd2, $rrev2, $vfwd2, $vrev2, $gt2, $af2, $bias2, $pmean2, $pstd2, $qual2, $qstd2, $mapq2, $sn2, $hiaf2, $adjaf2, $nm2, $sbf2, $oddratio2, $shift3, $msi, $msilen, $lseq, $rseq, $seg, $status, $type, $pvalue, $oddratio)  = @$d;
+	    my ($sample, $gene, $chrt, $start, $end, $ref, $alt, $dp1, $vd1, $rfwd1, $rrev1, $vfwd1, $vrev1, $gt1, $af1, $bias1, $pmean1, $pstd1, $qual1, $qstd1, $mapq1, $sn1, $hiaf1, $adjaf1, $nm1, $sbf1, $oddratio1, $dp2, $vd2, $rfwd2, $rrev2, $vfwd2, $vrev2, $gt2, $af2, $bias2, $pmean2, $pstd2, $qual2, $qstd2, $mapq2, $sn2, $hiaf2, $adjaf2, $nm2, $sbf2, $oddratio2, $shift3, $msi, $msilen, $lseq, $rseq, $seg, $status, $type, $sv1, $duprate1, $sv2, $duprate2, $pvalue, $oddratio)  = @$d;
 	    my $rd1 = $rfwd1 + $rrev1;
 	    my $rd2 = $rfwd2 + $rrev2;
 	    next if ( $seen{ "$chrt-$start-$end-$ref-$alt" } );

--- a/vardict.pl
+++ b/vardict.pl
@@ -2031,7 +2031,7 @@ sub toVars {
 		    }
 		    $tcov = $ttcov;
 		}
-        my $nm = sprintf("%.1f", $cnt->{ nm }/$cnt->{ cnt });
+		my $nm = sprintf("%.1f", $cnt->{ nm }/$cnt->{ cnt });
 		my $tvref = {n => $n, cov => $cnt->{ cnt }, fwd => $fwd, rev => $rev, bias => $bias, freq => sprintf("%.4f",$cnt->{ cnt }/$ttcov), pmean => sprintf("%.1f", $cnt->{ pmean }/$cnt->{ cnt } ), pstd => $cnt->{ pstd }, qual => $vqual, qstd => $cnt->{ qstd }, mapq => $MQ, qratio => sprintf("%.3f", $hicnt/($locnt ? $locnt : $locnt+0.5)), hifreq => ($hicov > 0 && $hicnt ? sprintf("%.4f", $hicnt/$hicov) : 0), extrafreq => $cnt->{ extracnt } ? sprintf("%.4f",$cnt->{ extracnt }/$ttcov) : 0, shift3 => 0, msi => 0, nm => ($nm > 0 ? $nm : 0), hicnt => $hicnt, hicov => $hicov, duprate => $duprate };
 		push(@var, $tvref);
 		if ( $opt_D ) {


### PR DESCRIPTION
**Can be merged after discussion with Zhongwu Lai about StrongLOH type changes.**
### Description 
This PR adds fixes:
* Fixed roundings for fields in `combineAnalysis()` and `toVars()`: pmean, qual, mapq, hifreq, extrafreq, nm and freq. Now they have the same roundings as in other parts of vardict. 
* Output for StrongLOH type in the paired analysis that causes the error with an incorrect count of columns while using `testsomatic.R`. Zero fields are now outputting for the first variant (number of columns will be the same as for other variant types).
* NM negative values are now zero.
* Added fields for sv and duprate in `var2vcf_paired.pl`.