### PR TITLE
Fixed SVs appear from realignment if option -U set.

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -2250,6 +2250,15 @@ sub toVars {
 		$vref->{ DEBUG } = join(" & ", @tmp) if ( $opt_D );
 
 	    }
+	    # delete SV from realignment
+	    if ($opt_U) {
+            for(my $vi = 0; $vi < @{ $vars{ $p }->{ VAR } }; $vi++) {
+                my $vref = $vars{ $p }->{ VAR }->[$vi];
+                if ($vref->{ varallele } =~ /<(...)>/ ) {
+                   delete $vars{ $p }->{ VAR }->[$vi];
+                }
+            }
+        }
 	} elsif ( $vars{$p}->{ REF } ) {
 	    my $vref = $vars{$p}->{ REF };  # no variant reads are detected.
 	    $vref->{ tcov } = $tcov;


### PR DESCRIPTION
This PR fixes bug with extra SVs in output while using option `--nosv` (issue https://github.com/AstraZeneca-NGS/VarDictJava/issues/143).
* Added removing of detected SVs at the end of toVars() method.