### PR TITLE
Fixed rrc count on direction and zero deletion after modify cigar

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -2077,7 +2077,8 @@ sub toVars {
 	}
 	if ( $tcov > $cov->{ $p } && $hash->{ $p + 1 } && $hash->{ $p + 1 }->{ $REF->{ $p + 1 } } ) {
 	    my $tpref = $hash->{ $p + 1 }->{ $REF->{ $p + 1 } };
-	    ($rfc, $rrc) = ($tpref->{ 1 }, $tpref->{ -1 });
+	    $rfc = $tpref->{ 1 } ? $tpref->{ 1 } : 0;
+	    $rrc = $tpref->{ -1 } ? $tpref->{ -1 } : 0;
 	}
 	# only reference reads are observed.
 	if ( $vars{ $p }->{ VAR } ) {

--- a/vardict.pl
+++ b/vardict.pl
@@ -1007,7 +1007,11 @@ sub parseSAM {
 		    if ( $tslen <= 0 ) {
 			$dlen -= $tslen;
 			$rm += $tslen;
-			$tslen = $dlen . "D" . $rm . "M";
+			if ($dlen > 0) {
+			    $tslen = $dlen . "D" . $rm . "M";
+			} else {
+			    $tslen = $rm . "M";
+			}
 		    } else {
 			$tslen = "${dlen}D${tslen}I${rm}M";
 		    }
@@ -1247,7 +1251,7 @@ sub parseSAM {
 	    $RLEN = $rlen2 if ($rlen2 > $RLEN); # Determine the read length
 
 	    next if ( $opt_F && $a[1] & 0x800 ); # Ignore the supplementary alignment so that it won't skew the coverage
-	    
+
 	    # Determine whether to filter a read in CRISPR mode
 	    if ( $opt_J ) {
 		my $rlen3= 0; $rlen3 += $1 while( $a[5] =~ /(\d+)[MD=X]/g ); # The total aligned length, excluding soft-clipped bases and insertions

--- a/vardict.pl
+++ b/vardict.pl
@@ -1007,11 +1007,8 @@ sub parseSAM {
 		    if ( $tslen <= 0 ) {
 			$dlen -= $tslen;
 			$rm += $tslen;
-			if ($dlen > 0) {
-			    $tslen = $dlen . "D" . $rm . "M";
-			} else {
-			    $tslen = $rm . "M";
-			}
+            $tslen = $dlen . "D" . $rm . "M";
+            ($RDOFF, $tslen) = ($RDOFF+$rm, "") if ( $dlen == 0);
 		    } else {
 			$tslen = "${dlen}D${tslen}I${rm}M";
 		    }


### PR DESCRIPTION
This PR fixed two issues:
* Missing values in reference counts when variant doesn't have values for them in direction:  https://github.com/AstraZeneca-NGS/VarDict/issues/72#issuecomment-438847828 
* **UPD:** This part already fixed by Zhongwu, was removed from commit: *Zero deletion in description string, when modify cigar creates the string with `0D` in the case of three indels (issue: https://github.com/AstraZeneca-NGS/VarDictJava/issues/173).*