### PR TITLE
Better support of gVCF and VCF4.3 format for AD and AF keys

### DIFF
--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -41,7 +41,7 @@ print <<VCFHEADER;
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
 ##INFO=<ID=END,Number=1,Type=Integer,Description="Chr End Position">
 ##INFO=<ID=VD,Number=1,Type=Integer,Description="Variant Depth">
-##INFO=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=BIAS,Number=1,Type=String,Description="Strand Bias Info">
 ##INFO=<ID=REFBIAS,Number=1,Type=String,Description="Reference depth by strand">
 ##INFO=<ID=VARBIAS,Number=1,Type=String,Description="Variant depth by strand">
@@ -92,7 +92,7 @@ print <<VCFHEADER;
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
 ##FORMAT=<ID=VD,Number=1,Type=Integer,Description="Variant Depth">
 ##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
-##FORMAT=<ID=AF,Number=1,Type=Float,Description="Allele Frequency">
+##FORMAT=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##FORMAT=<ID=RD,Number=2,Type=Integer,Description="Reference forward, reverse reads">
 ##FORMAT=<ID=ALD,Number=2,Type=Integer,Description="Variant forward, reverse reads">
 VCFHEADER


### PR DESCRIPTION
1. With the merge of https://github.com/AstraZeneca-NGS/VarDict/pull/58 and https://github.com/AstraZeneca-NGS/VarDict/pull/76, we now need to ensure we respect the type of the `AD` field when producing genome VCFs which can contain "no variant" records (no alternate alleles).

2. I have changed the reserved `INFO` and `FORMAT` tags for `AF` to `Number=A` as _per_ the [VCF specification](https://github.com/samtools/hts-specs/blob/9fd15c537de3008e7e3df5a69f256a9a6c64fc77/VCFv4.3.tex#L341):

| Key  | Number | Type    | Description                                                                                                          |
| ---  | ---    | ---     | ---                                                                                                                  |
| `AF` | `A`    | `Float` | Allele frequency for each ALT allele in the same order as listed (estimated from primary data, not called genotypes) |

Where `A` defines:

- The field has one value per alternate allele.
- The values must be in the same order as listed in the `ALT` column. 