### PR TITLE
Fix for realignins offset (substr outside of string error)

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -4724,7 +4724,7 @@ sub realignins {
 			my $flag = 0;
 			my $offset = ($sc3pp-$p-1) % length($ins);
 			my $tvn = $vn;
-			for(my $seqi = 0; $seqi < length($seq) && $seqi < length($ins); $seqi++ ) {
+			for(my $seqi = 0; $seqi < length($seq) && $seqi + $offset < length($ins); $seqi++ ) {
 			    if ( substr($seq, $seqi, 1) ne substr($ins, $seqi + $offset, 1) ) {
 				$flag++;
 				substr($tvn, $seqi + $offset + 1, 1) = substr($seq, $seqi, 1);


### PR DESCRIPTION
### Description
This PR fixes offset problem in `realignins()` for HCC2218 somatic set, when substr is outside of string because of the incorrect condition in the loop. 
Tests were added to Java version.