### PR TITLE
Fixes of issues 189, 192,193, 195 from VarDictJava repository

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -3057,7 +3057,7 @@ sub findDELdisc {
 	next unless( $mlen > 0 && $mlen > $MINDIST );
 	my $bp = $end + int(($RLEN/($cnt+1))/2);
 	$bp = $del->{ softp } if ( $del->{ softp } );
-	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen > 300 ? $mlen : 300) unless( $REF->{ $bp } );
+	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen < 1000 ? $mlen : 1000) unless( $REF->{ $bp } );
 	$hash->{ $bp }->{ "-$mlen" }->{ cnt } = 0;
 	$hash->{ $bp }->{ SV }->{ type } = "DEL";
 	$hash->{ $bp }->{ SV }->{ splits } += $sclip3->{ $end+1 } ? $sclip3->{ $end+1 }->{ cnt } : 0;
@@ -3082,7 +3082,7 @@ sub findDELdisc {
 	#use Object; print STDERR "3' $mlen ", Object::Perl($del), "\n";
 	next unless( $mlen > 0 && $mlen > $MINDIST );
 	my $bp = $me + int(($RLEN/($cnt+1))/2);
-	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen > 300 ? $mlen : 300) unless( $REF->{ $bp } );
+	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen < 1000 ? $mlen : 1000) unless( $REF->{ $bp } );
 	$hash->{ $bp }->{ "-$mlen" }->{ cnt } = 0;
 	$hash->{ $bp }->{ SV }->{ type } = "DEL";
 	$hash->{ $bp }->{ SV }->{ splits } += $sclip3->{ $me+1 } ? $sclip3->{ $me+1 }->{ cnt } : 0;

--- a/vardict.pl
+++ b/vardict.pl
@@ -1576,25 +1576,30 @@ sub parseSAM {
 		    if ( $start - 1 >= $START && $start -1 <= $END && $s !~ /N/ ) {
 			my $inspos = $start - 1;
 			if( $s =~ /^[ATGC]+$/ ) {
-			    ($inspos, $s) = adjInsPos($start-1, $s, $REF);
+			    my ($adjinspos, $adjs) = adjInsPos($start-1, $s, $REF);
+				if ($n-1-($start-1-$adjinspos) > 0) {
+					$inspos = $adjinspos;
+					$s = $adjs;
+				}
 			}
+
 			$ins{ $inspos }->{ "+$s" }++;
 			$hash->{ $inspos }->{ I }->{ "+$s" }->{ $dir }++;
 			my $hv = $hash->{ $inspos }->{ I }->{ "+$s" };
 			$hv->{ cnt }++;
-			my $tp = $p < $rlen-$p ? $p + 1: $rlen-$p;
+			my $tp = $p < $rlen - $p ? $p + 1 : $rlen - $p;
 			my $tmpq = 0;
-			for(my $i = 0; $i < length($q); $i++) {
-			    $tmpq += ord(substr($q, $i, 1))-33; 
+			for (my $i = 0; $i < length($q); $i++) {
+				$tmpq += ord(substr($q, $i, 1)) - 33;
 			}
 			$tmpq /= length($q);
-			unless( $hv->{ pstd } ) {
-			    $hv->{ pstd } = 0;
-			    $hv->{ pstd } = 1 if ($hv->{ pp } && $tp != $hv->{ pp });
+			unless ($hv->{ pstd }) {
+				$hv->{ pstd } = 0;
+				$hv->{ pstd } = 1 if ($hv->{ pp } && $tp != $hv->{ pp });
 			}
-			unless( $hv->{ qstd } ) {
-			    $hv->{ qstd } = 0;
-			    $hv->{ qstd } = 1 if ($hv->{ pq } && $tmpq != $hv->{ pq });
+			unless ($hv->{ qstd }) {
+				$hv->{ qstd } = 0;
+				$hv->{ qstd } = 1 if ($hv->{ pq } && $tmpq != $hv->{ pq });
 			}
 			$hv->{ pmean } += $tp;
 			$hv->{ qmean } += $tmpq;
@@ -1606,24 +1611,24 @@ sub parseSAM {
 
 			# Adjust the reference count for insertion reads
 			#if ( $REF->{ $inspos } && $hash->{ $inspos }->{ $REF->{ $inspos } } && substr($a[9], $n-1-($start-$inspos), 1) eq $REF->{ $inspos } ) {
-			    #subCnt($hash->{ $inspos }->{ $REF->{ $inspos } }, $dir, $tp, $tmpq, $a[4], $nm);
-			    subCnt($hash->{ $inspos }->{ substr($a[9], $n-1-($start-1-$inspos), 1) }, $dir, $tp, ord(substr($a[10], $n-1-($start-1-$inspos), 1))-33, $a[4], $nm - $nmoff) if ( $inspos > $a[3] && substr($a[9], $n-1-($start-1-$inspos), 1) eq $REF->{ $inspos } );
+			#subCnt($hash->{ $inspos }->{ $REF->{ $inspos } }, $dir, $tp, $tmpq, $a[4], $nm);
+			subCnt($hash->{ $inspos }->{ substr($a[9], $n - 1 - ($start - 1 - $inspos), 1) }, $dir, $tp, ord(substr($a[10], $n - 1 - ($start - 1 - $inspos), 1)) - 33, $a[4], $nm - $nmoff) if ($inspos > $a[3] && substr($a[9], $n - 1 - ($start - 1 - $inspos), 1) eq $REF->{ $inspos });
 			#}
 			# Adjust count if the insertion is at the edge so that the AF won't > 1
-			if ( $ci == 2 && ($cigar[1] eq "S" || $cigar[1] eq "H") ) {
-			    my $ttref = $hash->{ $inspos }->{ $REF->{ $inspos } };
-			    $ttref->{ $dir }++;
-			    $ttref->{ cnt }++;
-			    $ttref->{ pstd } = $hv->{ pstd };
-			    $ttref->{ qstd } = $hv->{ qstd };
-			    $ttref->{ pmean } += $tp;
-			    $ttref->{ qmean } += $tmpq;
-			    $ttref->{ Qmean } += $a[4];
-			    $ttref->{ pp } = $tp;
-			    $ttref->{ pq } = $tmpq;
-			    $ttref->{ nm } += $nm - $nmoff;
-			    #$cov->{ $inspos }->{ $REF->{ $inspos } }++;
-			    $cov->{ $inspos }++;
+			if ($ci == 2 && ($cigar[1] eq "S" || $cigar[1] eq "H")) {
+				my $ttref = $hash->{ $inspos }->{ $REF->{ $inspos } };
+				$ttref->{ $dir }++;
+				$ttref->{ cnt }++;
+				$ttref->{ pstd } = $hv->{ pstd };
+				$ttref->{ qstd } = $hv->{ qstd };
+				$ttref->{ pmean } += $tp;
+				$ttref->{ qmean } += $tmpq;
+				$ttref->{ Qmean } += $a[4];
+				$ttref->{ pp } = $tp;
+				$ttref->{ pq } = $tmpq;
+				$ttref->{ nm } += $nm - $nmoff;
+				#$cov->{ $inspos }->{ $REF->{ $inspos } }++;
+				$cov->{ $inspos }++;
 			}
 		    }
 		    $n += $m+$offset+$multoffp;

--- a/vardict.pl
+++ b/vardict.pl
@@ -1014,7 +1014,14 @@ sub parseSAM {
 			$tslen = $dlen . "D" . $rm . "M";
 			($RDOFF, $tslen) = ($RDOFF+$rm, "") if ( $dlen == 0 );
 		    } else {
-			$tslen = "${dlen}D${tslen}I${rm}M";
+				if ($dlen == 0) {
+					$tslen = "${tslen}I${rm}M";
+				} elsif ($dlen < 0) {
+					$rm += $dlen;
+					$tslen = "${tslen}I${rm}M";
+				} else {
+					$tslen = "${dlen}D${tslen}I${rm}M";
+				}
 		    }
 		    if ( $mid <= 15 ) {
 			#print STDERR "B: $rn $RDOFF $dlen $tslen $a[5]\n";

--- a/vardict.pl
+++ b/vardict.pl
@@ -3054,6 +3054,7 @@ sub findDELdisc {
 	next unless( $mlen > 0 && $mlen > $MINDIST );
 	my $bp = $end + int(($RLEN/($cnt+1))/2);
 	$bp = $del->{ softp } if ( $del->{ softp } );
+	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen > 300 ? $mlen : 300) unless( $REF->{ $bp } );
 	$hash->{ $bp }->{ "-$mlen" }->{ cnt } = 0;
 	$hash->{ $bp }->{ SV }->{ type } = "DEL";
 	$hash->{ $bp }->{ SV }->{ splits } += $sclip3->{ $end+1 } ? $sclip3->{ $end+1 }->{ cnt } : 0;
@@ -3078,6 +3079,7 @@ sub findDELdisc {
 	#use Object; print STDERR "3' $mlen ", Object::Perl($del), "\n";
 	next unless( $mlen > 0 && $mlen > $MINDIST );
 	my $bp = $me + int(($RLEN/($cnt+1))/2);
+	getREF($chr, $bp - 150, $bp + 150, $REF, $mlen > 300 ? $mlen : 300) unless( $REF->{ $bp } );
 	$hash->{ $bp }->{ "-$mlen" }->{ cnt } = 0;
 	$hash->{ $bp }->{ SV }->{ type } = "DEL";
 	$hash->{ $bp }->{ SV }->{ splits } += $sclip3->{ $me+1 } ? $sclip3->{ $me+1 }->{ cnt } : 0;


### PR DESCRIPTION
### Description
This PR fixes issues 189, 192, 193 and 195 from VarDictJava repository.
* Most of problems occurs for 3 indels case: in one case (issue 192) `$dlen` with (`$tslen` <0) becomes < 0 (it must be considered as insertion, and not deletion), in another case (issue 195) `$dlen ==0` with `$tslen` > 0 and this causes in incorrect calculation of `$msi`.
* For fixing issue 193 we have to keep non-adjusted insertion position. Here both insertion `3I` and deletion `6D` can be kept while reading CIGAR, because in another case there will be an attempt to create an insertion with `-3I` (instead of deletion).
* For fixing issue 189 added reference sequence loading for the case of DEL with discordant part missed in 5 case. Because there was found that length of bases about 300 can be not enough, added check for `$mlen` of segment.