### PR TITLE
Fixed X and Y chromosome recognition in pl scripts

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -240,7 +240,7 @@ sub reorder {
             $t =~ s/\D//g;
             push(@chrn, [$t, $c]);
         } else {
-            next if ( $c =~ /X/ || $c =~ /Y/ );
+        	next if ( $c eq "X" || $c eq "chrX" ||  $c eq "Y" ||  $c eq "chrY" );
             next if ( $c eq "MT" || $c eq "chrM" );
             push(@nonchrn, $c);
         }

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -239,7 +239,7 @@ sub reorder {
 	    $t =~ s/\D//g;
 	    push(@chrn, [$t, $c]);
 	} else {
-	    next if ( $c =~ /X/ || $c =~ /Y/ );
+		next if ( $c eq "X" || $c eq "chrX" ||  $c eq "Y" ||  $c eq "chrY" );
 	    next if ( $c eq "MT" || $c eq "chrM" );
 	    push(@nonchrn, $c);
 	}


### PR DESCRIPTION
### Description
This PR fixed issue  #[200](https://github.com/AstraZeneca-NGS/VarDictJava/issues/200) from VarDictJava repositoru. 
Fixed recognition of X and Y chromosomes in `var2vcf_valid.pl` and `var2vcf_paired.pl`. Prior to this, all chromosomes containing the symbols X and Y were recognized as allosomes.