### PR TITLE
Fixed tab for pileup mode.

### DIFF
--- a/testsomatic.R
+++ b/testsomatic.R
@@ -6,7 +6,7 @@ myfile = file("stdin")
 open(myfile, blocking=TRUE)
 myinput = readLines(myfile) # read from stdin
 if (length(myinput) > 0 ){
-    mynumcols = sapply(gregexpr("\\t+", myinput[1]), length) + 1 # count num of tabs + 1
+    mynumcols = sapply(gregexpr("\\t", myinput[1]), length) + 1 # count num of tabs + 1
 }else{
     mynumcols = 0
     d = matrix(0,0,0)

--- a/teststrandbias.R
+++ b/teststrandbias.R
@@ -5,7 +5,7 @@ myfile = file("stdin")
 open(myfile, blocking=TRUE)
 myinput = readLines(myfile) # read from stdin
 if (length(myinput) > 0 ){
-    mynumcols = sapply(gregexpr("\\t+", myinput[1]), length) + 1 # count num of tabs + 1
+    mynumcols = sapply(gregexpr("\\t", myinput[1]), length) + 1 # count num of tabs + 1
 }else{
     mynumcols = 0
     d = matrix(0,0,0)

--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -120,7 +120,7 @@ foreach my $chr (@chrs) {
 	    my $rd2 = $rfwd2 + $rrev2;
 	    next if ( $seen{ "$chrt-$start-$end-$ref-$alt" } );
 	    $seen{ "$chrt-$start-$end-$ref-$alt" } = 1;
-	    if ( not defined $type ) { $type = "REF"; }
+	    if ( not defined $type || $type eq "" ) { $type = "REF"; }
 	    #$pvalue *= sqrt(60/($mapq1+length($ref)+length($alt)-1))*$af1;
 	    my @filters = ();
 	    my @filters2 = ();

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -124,7 +124,7 @@ foreach my $chr (@chrs) {
 	    my ($sample, $gene, $chrt, $start, $end, $ref, $alt, $dp, $vd, $rfwd, $rrev, $vfwd, $vrev, $genotype, $af, $bias, $pmean, $pstd, $qual, $qstd, $sbf, $oddratio, $mapq, $sn, $hiaf, $adjaf, $shift3, $msi, $msilen, $nm, $hicnt, $hicov, $lseq, $rseq, $seg, $type, $gamp, $tamp, $ncamp, $ampflag) = @{ $tmp[$i] };
 	    next if ( $seen{ "$chrt-$start-$end-$ref-$alt" } );
 	    $seen{ "$chrt-$start-$end-$ref-$alt" } = 1;
-	    if ( not defined $type ) { $type = "REF"; }
+	    if ( not defined $type || $type eq "") { $type = "REF"; }
 	    my $isamp = 1 if ( defined($ampflag) );
 	    my $rd = $rfwd + $rrev;
 	    if ( $oddratio eq "Inf" ) {


### PR DESCRIPTION
### Description
This PR fixes issue #100.
* In pileup mode column "type" doesn't contain the type of variant (it is the empty string), so the error occurs when R script split the file by tabs. 
* Also fixed `var2vaf_valid.pl` and `var2vcf_paired.pl` because $type field is defined in such situation, but it is empty, so the final type now in VCF for reference variants will be "REF". 