### PR TITLE
Fixed issues 28 (option -o) and 82 (boundary conditions)

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -195,8 +195,8 @@ foreach my $chr (@chrs) {
 	    unless($opt_M) {
 		$filter = "PASS" if ( $filter ne "PASS" && @filters2 == 0 );
 	    }
-	    my $gt = (1-$af1 < $GTFREQ) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $FREQ ? "0/1" : "0/0"));
-	    my $gtm = (1-$af2 < $GTFREQ) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $FREQ ? "0/1" : "0/0"));
+	    my $gt = (1-$af1 < $GTFREQ) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $GTFREQ ? "0/1" : "0/0"));
+	    my $gtm = (1-$af2 < $GTFREQ) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $GTFREQ ? "0/1" : "0/0"));
 	    $bias1 =~ s/;/,/;
 	    $bias2 =~ s/;/,/;
 	    my $qual = $vd1 > $vd2 ? int(log($vd1)/log(2) * $qual1) : int(log($vd2)/log(2) * $qual2);

--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -120,7 +120,7 @@ foreach my $chr (@chrs) {
 	    my $rd2 = $rfwd2 + $rrev2;
 	    next if ( $seen{ "$chrt-$start-$end-$ref-$alt" } );
 	    $seen{ "$chrt-$start-$end-$ref-$alt" } = 1;
-	    if ( not defined $type || $type eq "" ) { $type = "REF"; }
+	    unless ($type) { $type = "REF"; }
 	    #$pvalue *= sqrt(60/($mapq1+length($ref)+length($alt)-1))*$af1;
 	    my @filters = ();
 	    my @filters2 = ();
@@ -195,8 +195,8 @@ foreach my $chr (@chrs) {
 	    unless($opt_M) {
 		$filter = "PASS" if ( $filter ne "PASS" && @filters2 == 0 );
 	    }
-	    my $gt = (1-$af1 < $GTFREQ) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $GTFREQ ? "0/1" : "0/0"));
-	    my $gtm = (1-$af2 < $GTFREQ) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $GTFREQ ? "0/1" : "0/0"));
+	    my $gt = (1-$af1 < $GTFREQ) ? "1/1" : ($af1 >= 0.5 ? "1/0" : ($af1 >= $FREQ ? "0/1" : "0/0"));
+	    my $gtm = (1-$af2 < $GTFREQ) ? "1/1" : ($af2 >= 0.5 ? "1/0" : ($af2 >= $FREQ ? "0/1" : "0/0"));
 	    $bias1 =~ s/;/,/;
 	    $bias2 =~ s/;/,/;
 	    my $qual = $vd1 > $vd2 ? int(log($vd1)/log(2) * $qual1) : int(log($vd2)/log(2) * $qual2);

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -3,15 +3,15 @@ use warnings;
 use Getopt::Std;
 use strict;
 
-our ($opt_d, $opt_v, $opt_f, $opt_h, $opt_H, 
-     $opt_p, $opt_q, $opt_F, $opt_S, $opt_Q, 
-     $opt_o, $opt_N, $opt_E, $opt_C, $opt_m, 
-     $opt_I, $opt_c, $opt_P, $opt_a, $opt_t, 
-     $opt_r, $opt_O, $opt_X, $opt_k, $opt_V, 
+our ($opt_d, $opt_v, $opt_f, $opt_h, $opt_H,
+     $opt_p, $opt_q, $opt_F, $opt_S, $opt_Q,
+     $opt_o, $opt_N, $opt_E, $opt_C, $opt_m,
+     $opt_I, $opt_c, $opt_P, $opt_a, $opt_t,
+     $opt_r, $opt_O, $opt_X, $opt_k, $opt_V,
      $opt_M, $opt_x, $opt_A, $opt_T, $opt_u,
      $opt_b);
 
-getopts('hutaHSCEAP:d:v:f:p:q:F:Q:s:N:m:I:c:r:O:X:k:V:M:x:T:b:') || Usage();
+getopts('hutaHSCEAP:d:v:f:p:q:F:Q:o:N:m:I:c:r:O:X:k:V:M:x:T:b:') || Usage();
 ($opt_h || $opt_H) && Usage();
 
 my $TotalDepth = $opt_d ? $opt_d : 3;
@@ -207,7 +207,7 @@ foreach my $chr (@chrs) {
 		$alt = ".";
 		$gt = "0/0";
 	    } else {
-		$gt = (1-$af < $GTFreq) ? "1/1" : ($af >= 0.5 ? "1/0" : ($af >= $Freq ? "0/1" : "0/0"));
+		$gt = (1-$af < $GTFreq) ? "1/1" : ($af >= 0.5 ? "1/0" : ($af >= $GTFreq ? "0/1" : "0/0"));
 	    }
 		# The AD field is a reserved VCF SAMPLE field of type `R`.
 		# This was patched in https://github.com/AstraZeneca-NGS/VarDict/pull/76

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -136,7 +136,7 @@ foreach my $chr (@chrs) {
 	    my ($sample, $gene, $chrt, $start, $end, $ref, $alt, $dp, $vd, $rfwd, $rrev, $vfwd, $vrev, $genotype, $af, $bias, $pmean, $pstd, $qual, $qstd, $sbf, $oddratio, $mapq, $sn, $hiaf, $adjaf, $shift3, $msi, $msilen, $nm, $hicnt, $hicov, $lseq, $rseq, $seg, $type, $gamp, $tamp, $ncamp, $ampflag) = @{ $tmp[$i] };
 	    next if ( $seen{ "$chrt-$start-$end-$ref-$alt" } );
 	    $seen{ "$chrt-$start-$end-$ref-$alt" } = 1;
-	    if ( not defined $type || $type eq "") { $type = "REF"; }
+	    unless ($type) { $type = "REF"; }
 	    my $isamp = 1 if ( defined($ampflag) );
 	    my $rd = $rfwd + $rrev;
 	    if ( $oddratio eq "Inf" ) {
@@ -207,7 +207,7 @@ foreach my $chr (@chrs) {
 		$alt = ".";
 		$gt = "0/0";
 	    } else {
-		$gt = (1-$af < $GTFreq) ? "1/1" : ($af >= 0.5 ? "1/0" : ($af >= $GTFreq ? "0/1" : "0/0"));
+		$gt = (1-$af < $GTFreq) ? "1/1" : ($af >= 0.5 ? "1/0" : ($af >= $Freq ? "0/1" : "0/0"));
 	    }
 		# The AD field is a reserved VCF SAMPLE field of type `R`.
 		# This was patched in https://github.com/AstraZeneca-NGS/VarDict/pull/76

--- a/vardict.pl
+++ b/vardict.pl
@@ -625,6 +625,7 @@ sub combineAnalysis {
 	    $var2->{ qratio } = $var1->{ qratio }; # Can't back calculate and should be inaccurate
 	    $var2->{ genotype } = $vref->{ genotype };
 	    $var2->{ bias } = strandBias($var2->{rfc}, $var2->{rrc}) . ";" . strandBias($var2->{fwd}, $var2->{rev});
+	    roundingAlmostZeros($var2);
 	    return "Germline";
 	} elsif ($vref->{ cov } < $var1->{ cov } - 2) {
 	    print STDERR "Combine produce less: $chr $p $nt $vref->{ cov } $var1->{ cov }\n" if ( $opt_y );

--- a/vardict.pl
+++ b/vardict.pl
@@ -4900,13 +4900,13 @@ sub adjSNV {
     }
 }
 
-#To update if after round variant fields become like 0.000
+#To update float value as a digit if after round value looks like 0.000 (appears for a very small values)
 sub roundingAlmostZeros {
 	my $tvref = shift;
 	my @fields = qw(freq pmean qual mapq qratio msi hifreq extrafreq nm duprate);
 	foreach my $key (@fields) {
 		if ($tvref-> { $key } == 0) {
-			$tvref-> { $key } = 0;
+			$tvref-> { $key } = int($tvref-> { $key });
 		}
 	}
 }

--- a/vardict.pl
+++ b/vardict.pl
@@ -942,7 +942,7 @@ sub parseSAM {
 			$rdoff += $_ foreach(@rdp); 
 		    }
 		    my $rn = 0;
-		    $rn++ while( $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
+		    $rn++ while( $rdoff + $rn < length($a[9]) && $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
 		    $RDOFF += $rn;
 		    $dlen -= $rn;
 		    $tslen -= $rn;
@@ -975,7 +975,7 @@ sub parseSAM {
 			$rdoff += $_ foreach(@rdp); 
 		    }
 		    my $rn = 0;
-		    $rn++ while( $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
+		    $rn++ while( $rdoff + $rn < length($a[9]) &&  $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
 		    $RDOFF += $rn;
 		    $dlen -= $rn;
 		    $tslen -= $rn;
@@ -1013,7 +1013,7 @@ sub parseSAM {
 			$rdoff += $_ foreach(@rdp); 
 		    }
 		    my $rn = 0;
-		    $rn++ while( $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
+		    $rn++ while($rdoff + $rn < length($a[9]) && $REF->{ $refoff + $rn } && $REF->{ $refoff + $rn } eq substr($a[9], $rdoff + $rn, 1) );
 		    $RDOFF += $rn;
 		    $dlen -= $rn;
 		    $tslen -= $rn;
@@ -1135,10 +1135,10 @@ sub parseSAM {
 			my ($rrn, $rmch) = (0, 0);
 			while( $rrn < $mch && $rn < $mch) {
 			    last unless( $REF->{ $refoff - $rrn - 1 } );
-			    if ( $REF->{ $refoff - $rrn - 1 } ne substr($a[9], $rdoff - $rrn - 1, 1) ) {
+			    if ( $rrn < $rdoff && $REF->{ $refoff - $rrn - 1 } ne substr($a[9], $rdoff - $rrn - 1, 1) ) {
 				$rn = $rrn+1;
 				$rmch = 0;
-			    } elsif ( $REF->{ $refoff - $rrn - 1 } eq substr($a[9], $rdoff - $rrn - 1, 1) ) {
+			    } elsif ( $rrn < $rdoff && $REF->{ $refoff - $rrn - 1 } eq substr($a[9], $rdoff - $rrn - 1, 1) ) {
 				$rmch++;
 			    }
 			    $rrn++;
@@ -1168,10 +1168,10 @@ sub parseSAM {
 		my ($rrn, $rmch) = (0, 0);
 		while( $rrn < $mch && $rn < $mch ) {
 		    last unless( $REF->{ $refoff - $rrn - 1 } );
-		    if ( $REF->{ $refoff - $rrn - 1 } ne substr($a[9], $rdoff - $rrn - 1, 1) ) {
+		    if ( $rrn < $rdoff && $REF->{ $refoff - $rrn - 1 } ne substr($a[9], $rdoff - $rrn - 1, 1) ) {
 			$rn = $rrn+1;
 			$rmch = 0;
-		    } elsif ( $REF->{ $refoff - $rrn - 1 } eq substr($a[9], $rdoff - $rrn - 1, 1) ) {
+		    } elsif ( $rrn < $rdoff && $REF->{ $refoff - $rrn - 1 } eq substr($a[9], $rdoff - $rrn - 1, 1) ) {
 			$rmch++;
 		    }
 		    $rrn++;


### PR DESCRIPTION
### Description
This PR fixes 2 issues:
* #28 - option `-o` for signal noise in `getopts` list for var2vcf_valid.pl fixed. But genotype field must be checked as it is (by lower threshold it is checked by `-f` option (`$FREQ`) instead of `-F` option (`$GTFREQ` field)). This described in the help for `-F` command: https://github.com/AstraZeneca-NGS/VarDict/blob/master/var2vcf_paired.pl#L314  
* #82 - added boundary conditions in cigar modifying step that were already added in Java version. 
* Rounding of small values for combineAnalysis() method added (some float values are calculated there right before output).