### PR TITLE
Scripts for parallel run of R and pl scripts

### DIFF
--- a/additions/run_each_file.sh
+++ b/additions/run_each_file.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SCRIPT FOR EACH FILE. It will run R and pl script for each file and create vcf gz and tabix.
+DIR_R=r
+DIR_VCF=vcf
+DIR_VAR=var
+FILE=$1
+#Extract filename
+FILENAME="$(basename -- $FILE)"
+FILENAME="${FILENAME%.*}"
+#Run R
+cat $FILE | testsomatic.R > ../$DIR_R/$FILENAME.r.var
+#Run pl scripts
+cat ../$DIR_R/$FILENAME.r.var | var2vcf_paired.pl > ../$DIR_VCF/$FILENAME.vcf
+#ZIP
+bgzip -f ../$DIR_VCF/$FILENAME.vcf
+tabix -f -p vcf ../$DIR_VCF/$FILENAME.vcf.gz 
+#Delete raw, r and not zipped VCF files
+rm ../$DIR_VAR/$FILENAME.var
+rm ../$DIR_R/$FILENAME.r.var
+rm ../$DIR_VCF/$FILENAME.vcf

--- a/additions/split_and_process_var.sh
+++ b/additions/split_and_process_var.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#Script for run .R and .pl scripts on big VAR files (for example for gVCF or WGS calling).
+#It will split VAR file by chromosomes and run the second script for each file.
+#Usage: ./split_and_process_var.sh filename
+
+INITIAL_VAR=$1
+COMBINED="output"
+DIR_R=r
+DIR_VCF=vcf
+DIR_VAR=var
+mkdir $DIR_R
+mkdir $DIR_VCF
+mkdir $DIR_VAR
+
+#Number of  concurrent jobs to run in one time. Can be changed by number of threads.
+JOBS=3
+
+#split var by chromosomes to var files in subfolder
+awk '{print > "var/"$2".var"}' $INITIAL_VAR
+
+#Run in parallel task for each var file
+cd $DIR_VAR
+find . -name "*.var" | parallel --jobs $JOBS -I% --max-args 1 ../run_each_file.sh %
+
+#Concatecation of VCFs
+cd ../$DIR_VCF
+vcfs=(*.vcf.gz)
+vcf-concat ${vcfs[@]} > ../$COMBINED.vcf
+cd ..
+bgzip -f $COMBINED.vcf 
+tabix -f -p vcf $COMBINED.vcf.gz 

--- a/additions/split_and_process_var.sh
+++ b/additions/split_and_process_var.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 #Script for run .R and .pl scripts on big VAR files (for example for gVCF or WGS calling).
 #It will split VAR file by chromosomes and run the second script for each file.
+
 #Usage: ./split_and_process_var.sh filename
+#Requirements:
+# * GNU parallel (can be installed from packages)
+# * vcf-tools
 
 INITIAL_VAR=$1
 COMBINED="output"


### PR DESCRIPTION
### Description
Added scripts for running R and pl on huge data by splitting by chromosomes. 

The problem appeared with gVCF (https://github.com/AstraZeneca-NGS/VarDictJava/issues/227), for example, raw output for exome run was about 55 Gb and R script can be very memory consuming (192Gb RAM wasn't enough), so it is better to split raw output of VarDict to several files and process them in parallel.
