### PR TITLE
Fixed SV for VCF merge.

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -2254,7 +2254,7 @@ sub toVars {
 			substr($varallele, 0, 1) = "";
 			$sp++;
 		    }
-		    if ($varallele eq "<DEL>" && length($refallele) > 1) {
+		    if ($varallele eq "<DEL>" && length($refallele) >= 1) {
 			$refallele = $REF->{ $sp };
 			$tcov = $cov->{ $sp - 1 } if ($cov->{ $sp - 1 });
 			$tcov = $vref->{ cov } if ( $vref->{ cov } > $tcov );


### PR DESCRIPTION
### Description

This PR fixes issue 225 from Java repository (vcf merge fail, https://github.com/AstraZeneca-NGS/VarDictJava/issues/225) which causes by incorrect REF allele on the position for some cases of DEL SV (when DEL SV is followed by matched sequence). Before this change REF allele was taken from the position of the last nucleotide in the DEL sequence and not at the place where it was deleted at reference. 