### PR TITLE
Fixed issue 226 (Java) repeat variant lines 

### DIFF
--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -192,7 +192,12 @@ foreach my $chr (@chrs) {
 	    unless( $isamp ) {
 	        ($splitreads, $spanpairs, $cluster) = (split(/-/, $tamp)) if ( defined($tamp) && $tamp =~ /-/ ); 
 		if ( $alt =~ /</ ) {
-		    next unless ( $splitreads >= $opt_T ); # Ignore SV's without split read support for now until a better criteria
+			# Ignore SV's without split read support for now until a better criteria
+			unless ( $splitreads >= $opt_T ) {
+				#To avoid duplication of previous variant if SV was skipped and pinfo1 still is not empty
+				$pinfo1 = "";
+				next;
+			}
 		    my $svlen = $end - $start;
 		    $svlen++ if ( $alt =~ /INV/ );
 		    $SVINFO = ";SVTYPE=$alt;SVLEN=$svlen";


### PR DESCRIPTION
### Description
If some variant is followed by SV and this SV is skipped due to filter (without split read support), then information about the variant will still be saved in `$pinfo1` field and will be output twice.
Issue: https://github.com/AstraZeneca-NGS/VarDictJava/issues/226
Added `$pinfo1` field clear to avoid duplication of variant if SV was skipped.