### PR TITLE
Avoid warnings for uninitialized value

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -4908,7 +4908,7 @@ sub roundingAlmostZeros {
 	my $tvref = shift;
 	my @fields = qw(freq pmean qual mapq qratio msi hifreq extrafreq nm duprate);
 	foreach my $key (@fields) {
-		if ($tvref-> { $key } == 0) {
+		if (defined $tvref-> { $key } && $tvref-> { $key } == 0) {
 			$tvref-> { $key } = int($tvref-> { $key });
 		}
 	}


### PR DESCRIPTION
### Description
Added check that the value is initialized. The results won't change because of this PR but it is better to avoid extra warnings in the console.