### PR TITLE
Fix issue 243 from Java repository: cigar in 3 indels

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -1025,7 +1025,13 @@ sub parseSAM {
 			if ($dlen == 0) {
 			($RDOFF, $tslen) = ($RDOFF + $rm, "");
 			} elsif ($dlen < 0) {
-			$tslen = -$dlen . "I" . ($rm + $dlen) . "M";
+				$rm += $dlen;
+				if ($rm < 0) {
+					$RDOFF = $RDOFF + $rm;
+					$tslen = -$dlen . "I";
+				} else {
+					$tslen = -$dlen . "I" . $rm . "M";
+				}
 			}
 			} else {
 				if ($dlen == 0) {


### PR DESCRIPTION
### Description
This PR fixes issue https://github.com/AstraZeneca-NGS/VarDictJava/issues/243. 

* Cigar modify for 3 indels is changed in the case when a match on reference can be with a shift to the left. Thus rm can be negative and then it must decrease first matched segment.
* Unit test and integration test case were added.