### PR TITLE
Fixed issue 253 from Java repository

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -1062,7 +1062,7 @@ sub parseSAM {
 		    }
 		}
 
-		# Combine two close deletions (<10bp) into one
+		# Combine two close deletions (<15bp) into one
 		if ($a[5] =~ /(\d+)D(\d+)M(\d+)([DI])(\d+I)?/o ) {
 		    if ( $2 <= 15 ) {
 			my $dlen = $1 + $2 + ($4 eq "D" ? $3 : 0);
@@ -1076,7 +1076,7 @@ sub parseSAM {
 		    }
 		}
 
-		# Combine two close indels (<10bp) into one
+		# Combine two close indels (<15bp) into one
 		if ($a[5] =~ /(\D)(\d+)I(\d+)M(\d+)([DI])(\d+I)?/o && $1 ne "D" && $1 ne "H") {
 		    if ( $3 <= 15 ) {
 			my $dlen = $3 + ($5 eq "D" ? $4 : 0);

--- a/vardict.pl
+++ b/vardict.pl
@@ -1077,7 +1077,7 @@ sub parseSAM {
 		}
 
 		# Combine two close indels (<10bp) into one
-		if ($a[5] =~ /(\D)(\d+)I(\d+)M(\d+)([DI])(\d+I)?/o && $1 ne "D") {
+		if ($a[5] =~ /(\D)(\d+)I(\d+)M(\d+)([DI])(\d+I)?/o && $1 ne "D" && $1 ne "H") {
 		    if ( $3 <= 15 ) {
 			my $dlen = $3 + ($5 eq "D" ? $4 : 0);
 			my $ilen = $2 + $3 + ($5 eq "I" ? $4 : 0);


### PR DESCRIPTION
Fixed case when deletion can appear next to hard clip after modifying CIGAR.

In the step of combining two close indels (<15 bp), we don't combine them if CIGAR starts from deletion to avoid errors in further step when creating a deletion variant. But for hard-clip situation must be same, because after combining we get deletion at the start of the CIGAR.

Added skipping combining indels after hard-clip.
Also fixed outdated comments.