### PR TITLE
Fixed issue 267 Java: IUPAC ambiguity codes in reference

### DIFF
--- a/vardict.pl
+++ b/vardict.pl
@@ -147,6 +147,8 @@ my %REVCOMP = ( A => "T", T => "A", C => "G", G => "C" );
 my $SVFLANK = 50; # the flanking sequence length for SV
 my $MINSVCDIST = 1.5; # the minimum distance between two SV clusters in term of read length
 my %SOFTP2SV;
+my %IUPAC_AMBIGUITY_CODES = (M => "A", R => "A",  W => "A", S => "C", Y => "C", K => "G", V => "A",
+	H => "A",  D => "A", B => "C");
 if ( $opt_p ) {
     $FREQ = -1;
     $MINR = 0;
@@ -423,6 +425,9 @@ sub vardict {
 	    for(my $i = 0; $i < @{ $pv->{VAR} }; $i++) {
 		my $vref = $pv->{ VAR }->[$i];
 		last if ( $vref->{refallele} =~ /N/ );
+		if ($vref->{ refallele } eq $vref->{ varallele }) {
+		    next unless( $opt_p );
+		}
 		my $vartype = varType($vref->{refallele}, $vref->{varallele});
 		unless( isGoodVar( $pv->{ VAR }->[$i], $pv->{ REF }, $vartype ) ) {
 		    next unless( $opt_p );
@@ -2395,7 +2400,7 @@ sub toVars {
 		$vref->{ sp } = $sp;
 		#$vref->{ ep } = $genotype =~ /\+(\d+)/ ? $sp + $1 : $ep;
 		$vref->{ ep } = $ep;
-		$vref->{ refallele } = $refallele;
+		$vref->{ refallele } = validateRefallele($refallele);
 		$vref->{ varallele } = $varallele;
 		$vref->{ genotype } = $genotype;
 		$vref->{ tcov } = $tcov;
@@ -2430,8 +2435,8 @@ sub toVars {
 	    $vref->{ sp } = $p;
 	    $vref->{ ep } = $p;
 	    $vref->{ hifreq } = sprintf("%.4f", $vref->{ hifreq }) if ($vref->{ hifreq });
-	    $vref->{ refallele } = $REF->{$p};
-	    $vref->{ varallele } = $REF->{$p};
+	    $vref->{ refallele } = validateRefallele($REF->{$p});
+	    $vref->{ varallele } = validateRefallele($REF->{$p});
 	    $vref->{ genotype } = "$REF->{$p}/$REF->{$p}";
 	    $vref->{ leftseq } = "";
 	    $vref->{ rightseq } = "";
@@ -2443,6 +2448,16 @@ sub toVars {
     return \%vars;
 }
 
+# Change IUPAC codes to first alphabetically
+sub validateRefallele {
+	my $refallele = shift;
+	while (my ($key, $value) = each %IUPAC_AMBIGUITY_CODES) {
+		if (index($refallele, $key) != -1) {
+			$refallele =~ s/$key/$value/;
+		}
+	}
+	return $refallele;
+}
 # Find closest mismatches to combine with indels
 sub findOffset {
     my ($refp, $readp, $mlen, $rdseq, $qstr, $REF, $cov) = @_;


### PR DESCRIPTION
### Description
* Added validation of reference base (REF field): in case when REF contains bases with IUPAC ambiguity code, then such bases will be changed to the one that is first alphabetically (as in spec: https://samtools.github.io/hts-specs/VCFv4.3.pdf).
* For pileup mode (gVCF like) when REF and ALT can be the same, ALT also will be updated as REF