### PR TITLE
Disable scientific notification in R

### DIFF
--- a/testsomatic.R
+++ b/testsomatic.R
@@ -46,6 +46,8 @@ if (nrow(d) > 0){
 	pvalues[i] <- round(pv, 5)
 	oddratio[i] <- round(od, 5)
     }
-
+    curscipen <- getOption("scipen")
+    options(scipen=999)
     write.table(data.frame(d[,1:25], pvalues1, oddratio1, d[,26:43], pvalues2, oddratio2, d[, 44:dim(d)[2]], pvalues, oddratio), file = "", quote = F, sep = "\t", eol = "\n", row.names=F, col.names=F)
+    options(scipen=curscipen)
 }

--- a/teststrandbias.R
+++ b/teststrandbias.R
@@ -25,5 +25,8 @@ if (nrow(d) > 0){
         pvalues[i] <- round(h$p.value, 5)
         oddratio[i] <- round(h$estimate, 5)
     }
+    curscipen <- getOption("scipen")
+    options(scipen=999)
     write.table(data.frame(d[,1:20], pvalues, oddratio, d[,21:dim(d)[2]]), file = "", quote = F, sep = "\t", eol = "\n", row.names=F, col.names=F)
+    options(scipen=curscipen)
 }


### PR DESCRIPTION
 ### Description
This PR disable the default scientific notification that R used (scipen=0). Because R script can change values like 0.0009 to 9E-4 after writing to the table, the result of comparing such values with simple "diff" that we use in integration testing will fail. 
It will save the current value end to return it after processing (not to change user settings). 