### PR TITLE
Rollback to VCF 4.2

### DIFF
--- a/var2vcf_paired.pl
+++ b/var2vcf_paired.pl
@@ -11,7 +11,7 @@ our ($opt_d, $opt_v, $opt_f, $opt_h, $opt_H,
 	$opt_r, $opt_O, $opt_X, $opt_k, $opt_V,
 	$opt_x, $opt_A, $opt_b, $opt_G);
 
-our $VERSION = "1.8.1";
+our $VERSION = "1.8.2";
 
 getopts('htHSCMAd:v:f:p:q:F:Q:o:P:N:m:c:I:D:r:O:X:k:V:x:b:G:') || Usage();
 ($opt_h || $opt_H) && Usage();
@@ -49,7 +49,7 @@ if ( $opt_N ) {
 (my $sample_nowhitespace = $sample) =~ s/\s/_/g;
 
 print <<VCFHEADER;
-##fileformat=VCFv4.3
+##fileformat=VCFv4.2
 ##source=VarDict_v$VERSION
 VCFHEADER
 

--- a/var2vcf_valid.pl
+++ b/var2vcf_valid.pl
@@ -11,7 +11,7 @@ our ($opt_d, $opt_v, $opt_f, $opt_h, $opt_H,
      $opt_M, $opt_x, $opt_A, $opt_T, $opt_u,
      $opt_b, $opt_G);
 
-our $VERSION = "1.8.1";
+our $VERSION = "1.8.2";
 
 getopts('hutaHSCEAP:d:v:f:p:q:F:Q:o:N:m:I:c:r:O:X:k:V:M:x:T:b:G:') || Usage();
 ($opt_h || $opt_H) && Usage();
@@ -44,7 +44,7 @@ $sample = $opt_N if ( $opt_N );
 (my $sample_nowhitespace = $sample) =~ s/\s/_/g;
 
 print <<VCFHEADER;
-##fileformat=VCFv4.3
+##fileformat=VCFv4.2
 ##source=VarDict_v$VERSION
 VCFHEADER
 

--- a/vardict.pl
+++ b/vardict.pl
@@ -15,7 +15,7 @@ our ($opt_h, $opt_H, $opt_b, $opt_D, $opt_d, $opt_s, $opt_c, $opt_S, $opt_E, $op
 #    USAGE();
 #}
 
-our $VERSION = "1.8.1";
+our $VERSION = "1.8.2";
 
 my @adaptor;
 my $CHIMERIC;


### PR DESCRIPTION
### Description
VCF version moved to 4.2. as htsjdk libraries doesn't fully supported it at the moment and we don't have any 4.3. features in VCFs.